### PR TITLE
Add Off hotkey type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # SDK
 Interesting..............
+
+## Keybind Types
+
+* **Always** - feature is always active.
+* **Hold** - hold the key to activate.
+* **Toggle** - press the key to toggle on or off.
+* **Off hotkey** - feature is active by default and held key temporarily disables it.

--- a/key_states.cpp
+++ b/key_states.cpp
@@ -98,21 +98,24 @@ void c_key_states::update(UINT uMsg, WPARAM wParam)
 	{
 		auto& b = g_cfg.binds[i];
 
-		if (b.key == -1 && b.type != 0)
-		{
-			b.toggled = false;
-			continue;
-		}
+                if (b.key == -1 && (b.type == 1 || b.type == 2))
+                {
+                        b.toggled = false;
+                        continue;
+                }
 
-		switch (b.type)
-		{
-		case 0:
-			b.toggled = true;
-			break;
-		case 1:
-			b.toggled = this->at(b.key);
-			break;
-		}
+                switch (b.type)
+                {
+                case 0:
+                        b.toggled = true;
+                        break;
+                case 1:
+                        b.toggled = this->at(b.key);
+                        break;
+                case 3:
+                        b.toggled = !this->at(b.key);
+                        break;
+                }
 
 		if (b.type == 2)
 		{

--- a/legacy ui/menu/menu elements/keybind.cpp
+++ b/legacy ui/menu/menu elements/keybind.cpp
@@ -139,8 +139,8 @@ bool c_menu::key_bind(const char* label, key_binds_t& var)
 
 	if (popup_open)
 	{
-		// 3 bind mods
-		float max_size = calc_max_popup_height(3);
+                // 4 bind mods
+                float max_size = calc_max_popup_height(4);
 
 		auto items_size = ImVec2(63.f, max_size * popup_mod.alpha);
 		SetNextWindowSize(items_size);
@@ -164,12 +164,14 @@ bool c_menu::key_bind(const char* label, key_binds_t& var)
 			return false;
 		}
 
-		if (this->selectable(CXOR("Always"), var.type == 0))
-			var.type = 0;
-		if (this->selectable(CXOR("Hold"), var.type == 1))
-			var.type = 1;
-		if (this->selectable(CXOR("Toggle"), var.type == 2))
-			var.type = 2;
+                if (this->selectable(CXOR("Always"), var.type == 0))
+                        var.type = 0;
+                if (this->selectable(CXOR("Hold"), var.type == 1))
+                        var.type = 1;
+                if (this->selectable(CXOR("Toggle"), var.type == 2))
+                        var.type = 2;
+                if (this->selectable(CXOR("Off hotkey"), var.type == 3))
+                        var.type = 3;
 
 		EndPopup();
 	}

--- a/legacy ui/menu/menu_indicators.cpp
+++ b/legacy ui/menu/menu_indicators.cpp
@@ -20,19 +20,22 @@ constexpr auto misc_ui_flags = ImGuiWindowFlags_NoSavedSettings
 
 std::string get_bind_type(int type)
 {
-	switch (type)
-	{
-	case 0:
-		return CXOR("[ enabled ]");
-		break;
-	case 1:
-		return CXOR("[ hold ]");
-		break;
-	case 2:
-		return CXOR("[ toggled ]");
-		break;
-	}
-	return "";
+        switch (type)
+        {
+        case 0:
+                return CXOR("[ enabled ]");
+                break;
+        case 1:
+                return CXOR("[ hold ]");
+                break;
+        case 2:
+                return CXOR("[ toggled ]");
+                break;
+        case 3:
+                return CXOR("[ off ]");
+                break;
+        }
+        return "";
 }
 
 void c_menu::draw_binds()


### PR DESCRIPTION
## Summary
- support an `Off hotkey` binding mode so a feature can be disabled while held
- show `[ off ]` indicator for this mode
- document new keybind type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683da176cbbc83249e63e95f2cf4e38a