### PR TITLE
Add aim point visualization feature

### DIFF
--- a/esp.cpp
+++ b/esp.cpp
@@ -7,6 +7,7 @@
 #include "penetration.hpp"
 #include "esp.hpp"
 #include "resolver.hpp"
+#include "ragebot.hpp"
 #include "legacy ui/menu/menu.h"
 
 constexpr auto MOLOTOV_ICON = (u8"\uE02E");
@@ -587,9 +588,24 @@ void c_esp::draw_player_esp()
 			return;
 		}
 
-		esp.valid = true;
+                esp.valid = true;
 
-		auto& bbox = esp.box;
+                auto& bbox = esp.box;
+
+                if (entity_visuals.elements & 512)
+                {
+                        auto& vis_point = *RAGEBOT->get_aim_point(index);
+                        if (vis_point.valid)
+                        {
+                                vec2_t screen{};
+                                if (RENDER->world_to_screen(vis_point.point, screen))
+                                {
+                                        auto clr = entity_visuals.colors.glow.base();
+                                        RENDER->circle_filled(screen.x, screen.y, 4.f, clr.new_alpha((int)(120 * esp.alpha)), 20);
+                                        RENDER->circle(screen.x, screen.y, 4.f, clr.new_alpha((int)(clr.a() * esp.alpha)), 20, 2.f);
+                                }
+                        }
+                }
 		if (entity_visuals.elements & 1)
 		{
 			RENDER->rect(bbox.x - 1, bbox.y - 1, bbox.w + 2, bbox.h + 2, { 0, 0, 0, (int)(150 * esp.alpha) }, 1.f);
@@ -672,11 +688,11 @@ void c_esp::draw_player_esp()
 					}
 
 #if _DEBUG || ALPHA || BETA
-					if (entity_visuals.elements & 512)
-					{
-						auto& info = resolver_info[player->index()];
-						EMPLACE_OBJECT(true, FONT_OUTLINE | FONT_LIGHT_BACK, FONT_PIXEL, ESP_POS_RIGHT, 0.f, 0.f, esp.alpha, { 255, 255, 255, 255 }, { 0, 0, 0, 255 }, info.mode);
-					}
+                                        if (entity_visuals.elements & 1024)
+                                        {
+                                                auto& info = resolver_info[player->index()];
+                                                EMPLACE_OBJECT(true, FONT_OUTLINE | FONT_LIGHT_BACK, FONT_PIXEL, ESP_POS_RIGHT, 0.f, 0.f, esp.alpha, { 255, 255, 255, 255 }, { 0, 0, 0, 255 }, info.mode);
+                                        }
 #endif
 				}
 			}

--- a/legacy ui/menu/menu_tabs.cpp
+++ b/legacy ui/menu/menu_tabs.cpp
@@ -1005,9 +1005,10 @@ void c_menu::draw_ui_items()
 							  XOR("Ammo"),
 							  XOR("Flags"),
 							  XOR("OOF Arrow"),
-							  XOR("Glow"),
+                                                          XOR("Glow"),
+                                                          XOR("Aim point"),
 #if _DEBUG || ALPHA || BETA
-							  XOR("Resolver mode"),
+                                                          XOR("Resolver mode"),
 #endif
 							//  XOR("Skeleton"),
 							});

--- a/ragebot.cpp
+++ b/ragebot.cpp
@@ -1183,14 +1183,20 @@ void c_ragebot::choose_best_point()
 					return best;
 				};
 
-			auto best_point = get_best_aim_point();
-			if (best_point.found)
-			{
-				rage->best_point = best_point;
-				rage->best_record = rage->hitscan_record;
-				rage->best_point.found = true;
-			}
-		});
+                        auto best_point = get_best_aim_point();
+                        if (best_point.found)
+                        {
+                                rage->best_point = best_point;
+                                rage->best_record = rage->hitscan_record;
+                                rage->best_point.found = true;
+
+                                aim_points[player->index()].valid = true;
+                                aim_points[player->index()].hitbox = best_point.hitbox;
+                                aim_points[player->index()].point = best_point.aim_point;
+                        }
+                        else
+                                aim_points[player->index()].valid = false;
+                });
 }
 
 void c_ragebot::auto_revolver()
@@ -1418,11 +1424,14 @@ void c_ragebot::run()
 	if (EXPLOITS->cl_move.trigger && EXPLOITS->cl_move.shifting)
 		return;
 
-	hitboxes.clear();
-	hitboxes.reserve(HITBOX_MAX);
+        hitboxes.clear();
+        hitboxes.reserve(HITBOX_MAX);
 
-	rage_config = main_utils::get_weapon_config();
-	update_hitboxes();
+        rage_config = main_utils::get_weapon_config();
+        update_hitboxes();
+
+        for (auto& pt : aim_points)
+                pt.valid = false;
 
 	trigger_stop = false;
 	should_shot = true;

--- a/ragebot.hpp
+++ b/ragebot.hpp
@@ -149,10 +149,26 @@ private:
 
 	std::vector<int> hitboxes{};
 
-	vec3_t predicted_eye_pos{};
-	rage_player_t rage_players[65]{};
+        vec3_t predicted_eye_pos{};
+        rage_player_t rage_players[65]{};
 
-	std::vector<aim_shot_record_t> shots{};
+        struct aim_point_visual_t
+        {
+                bool valid{};
+                int hitbox{};
+                vec3_t point{};
+
+                INLINE void reset()
+                {
+                        valid = false;
+                        hitbox = 0;
+                        point.reset();
+                }
+        };
+
+        aim_point_visual_t aim_points[65]{};
+
+        std::vector<aim_shot_record_t> shots{};
 
 	struct table_t
 	{
@@ -212,7 +228,12 @@ public:
 	bool revolver_fire{};
 	int missed_shots[65]{};
 	rage_player_t best_rage_player{};
-	rage_weapon_t rage_config{};
+        rage_weapon_t rage_config{};
+
+        INLINE aim_point_visual_t* get_aim_point(int idx)
+        {
+                return &aim_points[idx];
+        }
 
 	INLINE float get_dynamic_scale(const vec3_t& point, const float& hitbox_radius)
 	{
@@ -282,9 +303,12 @@ public:
 		rage_config = {};
 		best_rage_player.reset();
 		predicted_eye_pos.reset();
-		hitboxes.clear();
-		shots.clear();
-	}
+                hitboxes.clear();
+                shots.clear();
+
+                for (auto& i : aim_points)
+                        i.reset();
+        }
 
 	INLINE void build_seeds()
 	{


### PR DESCRIPTION
## Summary
- show selected aim points as glowing circles in ESP
- expose ragebot aim point data for rendering
- reset aim point info each run
- support toggling aim point display via new menu option

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683de7e7cd388324bbae7ea751caa8ba