### PR TITLE
Add Chinese UTF-8 font support

### DIFF
--- a/esp_object_render.cpp
+++ b/esp_object_render.cpp
@@ -19,7 +19,14 @@ namespace esp_objects
 		auto font_ptr = font->get();
 
 		auto list = RENDER->get_draw_list();
-		ImVec2 text_size = RENDER->get_text_size(font, object.string.c_str());
+                std::wstring wstr(object.string.begin(), object.string.end());
+                ImVec2 text_size = RENDER->get_text_size(font, object.string.c_str());
+                if (object.position == ESP_POS_UP)
+                {
+                        auto sz = RENDER->surface_text_size(RENDER->fonts.surface_esp, wstr);
+                        text_size.x = sz.x;
+                        text_size.y = sz.y;
+                }
 
 		auto add = ((BAR_WIDTH_X * 2.f)) * max_bar_width;
 		auto add_h = ((BAR_WIDTH_Y * 2.f)) * max_bar_width;
@@ -53,10 +60,19 @@ namespace esp_objects
 		break;
 		}
 
-		auto centered = object.position == ESP_POS_UP || object.position == ESP_POS_DOWN;
-		auto flags = (centered ? FONT_CENTERED_X : 0) | object.font_flags;
-		RENDER->text(position.x, position.y, object.clr.new_alpha((int)(object.clr.a() * object.alpha)),
-			flags, font, object.string);
+                auto centered = object.position == ESP_POS_UP || object.position == ESP_POS_DOWN;
+                auto flags = (centered ? FONT_CENTERED_X : 0) | object.font_flags;
+                if (object.position == ESP_POS_UP)
+                {
+                        RENDER->surface_text(position.x - (text_size.x * 0.5f), position.y,
+                                object.clr.new_alpha((int)(object.clr.a() * object.alpha)),
+                                RENDER->fonts.surface_esp, wstr);
+                }
+                else
+                {
+                        RENDER->text(position.x, position.y, object.clr.new_alpha((int)(object.clr.a() * object.alpha)),
+                                flags, font, object.string);
+                }
 
 		offset += text_size.y;
 	}

--- a/render.cpp
+++ b/render.cpp
@@ -375,7 +375,11 @@ bool c_render::init()
 	//	cfg.RasterizerFlags = ImGuiFreeType::RasterizerFlags::ForceAutoHint;
 	fonts.main.init(io, SFUIDisplay_SemiBold, sizeof(SFUIDisplay_SemiBold), 14.f, &cfg, io.Fonts->GetGlyphRangesCyrillic());
 	fonts.large.init(io, SFUIDisplay_SemiBold, sizeof(SFUIDisplay_SemiBold), 30.f, &cfg, io.Fonts->GetGlyphRangesCyrillic());
-	fonts.esp.init(io, CXOR("C:\\Windows\\Fonts\\verdana.ttf"), 12.f, &cfg, io.Fonts->GetGlyphRangesCyrillic());
+        // use a font that contains common simplified Chinese characters to fix
+        // "???" being rendered for UTF-8 text like Chinese in ESP
+        fonts.esp.init(io, CXOR("C:\\Windows\\Fonts\\msyh.ttc"), 12.f, &cfg, io.Fonts->GetGlyphRangesChineseSimplifiedCommon());
+        fonts.surface_esp = HACKS->surface->font_create();
+        HACKS->surface->set_font_glyph_set(fonts.surface_esp, "msyh.ttc", 12, 0, 0, 0, 0);
 	fonts.misc.init(io, SFUIDisplay_SemiBold, sizeof(SFUIDisplay_SemiBold), 14.f, &cfg, io.Fonts->GetGlyphRangesCyrillic());
 	fonts.bold.init(io, SFUIDisplay_Bold, sizeof(SFUIDisplay_Bold), 10.f, &cfg, io.Fonts->GetGlyphRangesCyrillic());
 	fonts.bold2.init(io, SFUIDisplay_Bold, sizeof(SFUIDisplay_Bold), 14.f, &cfg, io.Fonts->GetGlyphRangesCyrillic());

--- a/render.hpp
+++ b/render.hpp
@@ -72,6 +72,7 @@ private:
         c_d3dfont pixel{};
         c_d3dfont weapon_icons{};
         c_d3dfont weapon_icons_large{};
+        unsigned long surface_esp{};
     };
 
     float last_time_updated;
@@ -226,6 +227,21 @@ public:
         draw_list->AddText(font_base, font_size, pos, color.as_imcolor(), str);
 
         draw_list->PopTextureID();
+    }
+
+    INLINE vec2_t surface_text_size(unsigned long font, const std::wstring& wstr)
+    {
+        int w{}, h{};
+        HACKS->surface->get_text_size(font, wstr.c_str(), w, h);
+        return vec2_t((float)w, (float)h);
+    }
+
+    INLINE void surface_text(float x, float y, c_color color, unsigned long font, const std::wstring& wstr)
+    {
+        HACKS->surface->draw_set_text_font(font);
+        HACKS->surface->draw_set_text_color(color.r(), color.g(), color.b(), color.a());
+        HACKS->surface->draw_set_text_pos((int)x, (int)y);
+        HACKS->surface->draw_print_text(wstr.c_str(), wstr.size());
     }
 
     INLINE void blur(float x, float y, float w, float h, c_color clr, float rounding = 0.f)


### PR DESCRIPTION
## Summary
- improve ESP font setup for UTF-8 text
- draw player names with `c_surface` to support UTF-8 rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68401af8d86483248596b896e64a1588