### PR TITLE
Rewrite get_points with simplified logic

### DIFF
--- a/ragebot.hpp
+++ b/ragebot.hpp
@@ -128,6 +128,34 @@ struct rage_player_t
 	}
 };
 
+struct AimContext_t
+{
+        int m_iCurrentBestHitbox{};
+        c_cs_player* m_pCurrentBestTarget{};
+        int m_iTargetPlayerIndex{};
+        int m_iLastBestHitbox{};
+        bool m_bHasValidTarget{};
+        float m_flSomeTimestamp{};
+        int m_iSomeTargetID1{};
+        bool m_bIgnoreBounds{};
+        int m_iLastScannedHitbox{};
+        vec3_t m_vecLastScannedPoint{};
+        bool m_bAimbotHasTarget{};
+        c_cs_player* m_pFinalTarget{};
+        int m_iFinalHitbox{};
+        float m_flFinalDamage{};
+        vec3_t m_vecFinalPoint{};
+
+        INLINE void UpdateTargetPoint(const vec3_t&) {}
+        INLINE bool IsPointWithinBounds(const vec3_t&) const { return true; }
+        INLINE bool IsPointWithinSecondaryBounds(const vec3_t&) const { return true; }
+        INLINE void SetPointAsInvalid(int) {}
+        INLINE void ClearFailureFlags() {}
+        INLINE bool ShouldOverrideTarget(c_cs_player*) const { return true; }
+};
+
+bool Ragebot_RegisterAimPoint(AimContext_t* ctx, const vec3_t& point, c_cs_player* target, int hitbox);
+
 struct knife_point_t
 {
 	int damage{};


### PR DESCRIPTION
## Summary
- implement helper `Ragebot_RegisterAimPoint`
- rewrite `get_points` to use simplified multipoint scanning logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68446c0d04508324b45d252be5d3f349