### PR TITLE
Add grenade esp

### DIFF
--- a/esp.cpp
+++ b/esp.cpp
@@ -617,8 +617,21 @@ void c_esp::draw_player_esp()
 			esp.objects[i].reset();
 
 		// store esp objects 
-		{
-			int iter = 0;
+                {
+                        int iter = 0;
+
+                        if (entity_visuals.elements & 2048)
+                        {
+                                for (int g = 0; g < 4; ++g)
+                                {
+                                        if (esp.grenade_icons[g].empty())
+                                                continue;
+
+                                        auto clr = esp.grenade_active[g] ? c_color{255,255,255,255} : c_color{120,120,120,255};
+                                        EMPLACE_OBJECT(true, FONT_DROPSHADOW | FONT_LIGHT_BACK, FONT_ICON, ESP_POS_UP, 0.f, 0.f,
+                                                esp.alpha, clr, {0,0,0,255}, esp.grenade_icons[g]);
+                                }
+                        }
 			
 			if (entity_visuals.elements & 2)
 				EMPLACE_OBJECT(true, FONT_OUTLINE | FONT_LIGHT_BACK, FONT_PIXEL, ESP_POS_UP, 0.f, 0.f, esp.alpha, name_color, { 0, 0, 0, 255 }, player->get_name());

--- a/esp.hpp
+++ b/esp.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "esp_object_render.hpp"
+#include <array>
 
 struct weapon_esp_t
 {
@@ -78,6 +79,9 @@ struct esp_player_t
     std::string weapon_name{};
     std::string weapon_icon{};
 
+    std::array<std::string, 4> grenade_icons{};
+    std::array<bool, 4> grenade_active{};
+
     esp_dormant_t dormant{};
     esp_object_t objects[MAX_ESP_OBJECTS]{};
 
@@ -108,6 +112,30 @@ struct esp_player_t
                 planting = weapon->item_definition_index() == WEAPON_C4 && weapon->started_arming();
             }
         }
+
+        grenade_icons.fill("");
+        grenade_active.fill(false);
+
+        short active_idx = weapon ? weapon->item_definition_index() : -1;
+        auto weapons = player->get_weapons();
+        for (auto w : weapons)
+        {
+            if (!w || !w->is_grenade())
+                continue;
+
+            short idx = w->item_definition_index();
+            const char* icon = (const char*)w->get_weapon_icon();
+            int slot = -1;
+            if (idx == WEAPON_HEGRENADE) slot = 0;
+            else if (idx == WEAPON_SMOKEGRENADE) slot = 1;
+            else if (idx == WEAPON_FLASHBANG) slot = 2;
+            else if (idx == WEAPON_MOLOTOV || idx == WEAPON_FIREBOMB || idx == WEAPON_INCGRENADE) slot = 3;
+            if (slot == -1)
+                continue;
+
+            grenade_icons[slot] = icon;
+            grenade_active[slot] = idx == active_idx;
+        }
     }
 
     INLINE void reset()
@@ -131,6 +159,9 @@ struct esp_player_t
             name.clear();
             weapon_name.clear();
             weapon_icon.clear();
+
+            grenade_icons.fill("");
+            grenade_active.fill(false);
 
             std::memset(poses, 0, sizeof(poses));
 

--- a/legacy ui/menu/menu_tabs.cpp
+++ b/legacy ui/menu/menu_tabs.cpp
@@ -1010,8 +1010,9 @@ void c_menu::draw_ui_items()
 #if _DEBUG || ALPHA || BETA
                                                           XOR("Resolver mode"),
 #endif
-							//  XOR("Skeleton"),
-							});
+                                                          XOR("Grenades"),
+//  XOR("Skeleton"),
+                                                        });
 
 						if (enemy_esp.elements & 1)
 							color_picker(CXOR("Box color##esp_enemy"), enemy_esp.colors.box);


### PR DESCRIPTION
## Summary
- show grenade icons for each player
- highlight active grenade icon
- expose new ESP option in menu

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6853d58abe348324862efb64f2613d04